### PR TITLE
Optionally override platform hostname

### DIFF
--- a/lib/boardeffect/client.rb
+++ b/lib/boardeffect/client.rb
@@ -28,6 +28,7 @@ module BoardEffect
     def auth(path, attributes)
       http_request = Net::HTTP::Post.new(path)
       http_request['Content-Type'] = 'application/json'
+      http_request['Host'] = @platform if @platform
       http_request.body = JSON.generate(attributes)
       parse(@http.request(http_request))
     end
@@ -42,6 +43,8 @@ module BoardEffect
       @user_agent = options.fetch(:user_agent, 'Ruby BoardEffect::Client')
 
       @host = (options.key?(:host)) ? options[:host] : 'boardeffect.local'
+
+      @platform = options[:platform] if options.key?(:platform)
 
       @http = Net::HTTP.new(URI.parse(@host).host, Net::HTTP.https_default_port())
       @http.use_ssl = true
@@ -62,6 +65,7 @@ module BoardEffect
     def request(http_request, body_object = nil)
       http_request['User-Agent'] = @user_agent
       http_request[@auth_header] = @auth_value
+      http_request['Host'] = @platform if @platform
 
       if body_object
         http_request['Content-Type'] = 'application/json'

--- a/lib/boardeffect/version.rb
+++ b/lib/boardeffect/version.rb
@@ -1,3 +1,3 @@
 module BoardEffect
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
Optionally override the platform hostname with the option :platform in the constructor. This is useful to run API commands against a platform for which DNS is not working/public.